### PR TITLE
Using jcabi 0.49.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@ SOFTWARE.
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>parent</artifactId>
-    <version>0.49.5</version>
+    <version>0.49.9</version>
   </parent>
   <url>https://github.com/artipie/ppom</url>
   <description>Parent POM of Artipie</description>
@@ -86,21 +86,6 @@ SOFTWARE.
         <groupId>org.cactoos</groupId>
         <artifactId>cactoos</artifactId>
         <version>0.43</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${junit-platform.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${junit-platform.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-library</artifactId>
-        <version>2.1</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish</groupId>


### PR DESCRIPTION
Updated jcabi parent to fix hamcrest dependency artifact.
Related: https://github.com/jcabi/jcabi-parent/pull/93/