### PR TITLE
Artipie central repositories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+---
+name: Release Artifacts on git tags
+"on":
+  create:
+    tags:
+      - .*
+jobs:
+  release-to-artipie:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: jdk-1.8-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            jdk-1.8-maven-
+      - name: Deploy to Artipie central
+        run: mvn --settings=.release/settings.xml -B clean deploy -Partipie

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/
 .idea/
 *.iml
 .DS_Store
+.project
+.settings/**

--- a/.release/settings.xml
+++ b/.release/settings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!--
+MIT License
+
+Copyright (c) 2020 Artipie
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd">
+  <servers>
+    <server>
+      <id>artipie-central</id>
+      <username>${env.ARTIPIE_USERNAME}</username>
+      <password>${env.ARTIPIE_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,19 @@ SOFTWARE.
       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
   </distributionManagement>
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>artipie-central</id>
+      <name>Artipie central</name>
+      <url>https://central.artipie.com/artipie/maven</url>
+    </repository>
+  </repositories>
   <developers>
     <developer>
       <name>Kirill Che.</name>
@@ -325,6 +338,21 @@ SOFTWARE.
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>artipie-central</id>
+      <distributionManagement>
+        <repository>
+          <id>artipie-central</id>
+          <name>Artipie central</name>
+          <url>https://central.artipie.com/artipie/maven</url>
+        </repository>
+        <snapshotRepository>
+          <id>artipie-central</id>
+          <name>Artipie central</name>
+          <url>https://central.artipie.com/artipie/maven</url>
+        </snapshotRepository>
+      </distributionManagement>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
#25 - use Artipie central as additional option for downloading artifacts, and added profile to deploy to central as additional `distributionManagement` repository (it's supposed to run `deploy` with this profile after releasing to Maven central).