### PR TITLE
Disabled failing plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,16 @@ SOFTWARE.
             <additionalparam>-Xdoclint:none</additionalparam>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>com.jcabi</groupId>
+          <artifactId>jcabi-maven-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>jcabi-versionalize-packages</id>
+              <phase>none</phase>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Fixes #55 - disabled jcabi-versionalize-packages plugin
which is failing during build phase but it's not required
for build.