### PR TITLE
upd: clean and update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@ https://github.com/artipie/ppom/blob/master/LICENSE.txt
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <junit-platform.version>5.8.2</junit-platform.version>
-    <vertx.version>4.2.3</vertx.version>
+    <junit-platform.version>5.10.0</junit-platform.version>
+    <vertx.version>4.4.6</vertx.version>
     <javax.json.version>1.1.4</javax.json.version>
     <qulice.license>${project.basedir}/LICENSE.header</qulice.license>
   </properties>
@@ -100,17 +100,17 @@ https://github.com/artipie/ppom/blob/master/LICENSE.txt
       <dependency>
         <groupId>org.reactivestreams</groupId>
         <artifactId>reactive-streams</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.32</version>
+        <version>2.0.9</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
-        <version>2.0.0-alpha6</version>
+        <version>2.0.9</version>
       </dependency>
       <dependency>
         <groupId>log4j</groupId>
@@ -135,17 +135,12 @@ https://github.com/artipie/ppom/blob/master/LICENSE.txt
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.11.0</version>
+        <version>2.14.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.12.0</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>30.1.1-jre</version>
+        <version>3.13.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -217,20 +212,6 @@ https://github.com/artipie/ppom/blob/master/LICENSE.txt
           </configuration>
         </plugin>
         <plugin>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.0.0-M5</version>
-          <configuration>
-            <encoding>${project.build.sourceEncoding}</encoding>
-            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
-            <forkCount>0</forkCount>
-            <parallel>all</parallel>
-            <parallelTestsTimeoutForcedInSeconds>0</parallelTestsTimeoutForcedInSeconds>
-            <parallelTestsTimeoutInSeconds>0</parallelTestsTimeoutInSeconds>
-            <perCoreThreadCount>true</perCoreThreadCount>
-            <trimStackTrace>false</trimStackTrace>
-          </configuration>
-        </plugin>
-        <plugin>
           <artifactId>maven-jar-plugin</artifactId>
           <version>3.2.2</version>
         </plugin>
@@ -291,20 +272,6 @@ https://github.com/artipie/ppom/blob/master/LICENSE.txt
       </plugins>
     </pluginManagement>
     <plugins>
-      <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <parallel>none</parallel>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
Updated dependencies versions and removed `maven-failsafe-plugin`. Plugin `maven-failsafe-plugin` is not convenient in ppom as  it runs integration tests by default, not in separate profile. 